### PR TITLE
Removed the check-type assertion on the body parameter from the Patch…

### DIFF
--- a/lib/request-service-discovery.js
+++ b/lib/request-service-discovery.js
@@ -91,7 +91,6 @@ RequestServiceDiscovery.prototype.get = function(uri, options, callback) {
 RequestServiceDiscovery.prototype.put = function(uri, options, body, callback) {
   check.assert.string(uri, 'uri [string] must be provided');
   check.assert.maybe.object(options, 'options [object] must be provided');
-  check.assert.maybe.object(body, 'body [object] must be provided');
   check.assert.function(callback, 'callback [function] must be provided');
 
   this._request('PUT', uri, options, body, callback);
@@ -108,7 +107,6 @@ RequestServiceDiscovery.prototype.put = function(uri, options, body, callback) {
  RequestServiceDiscovery.prototype.post = function(uri, options, body, callback) {
   check.assert.string(uri, 'uri [string] must be provided');
   check.assert.maybe.object(options, 'options [object] must be provided');
-  check.assert.maybe.object(body, 'body [object] must be provided');
   check.assert.function(callback, 'callback [function] must be provided');
 
   this._request('POST', uri, options, body, callback);
@@ -140,7 +138,6 @@ RequestServiceDiscovery.prototype.delete = function(uri, options, body, callback
 RequestServiceDiscovery.prototype.patch = function(uri, options, body, callback) {
   check.assert.string(uri, 'uri [string] must be provided');
   check.assert.maybe.object(options, 'options [object] must be provided');
-  check.assert.maybe.object(body, 'body [object] must be provided');
   check.assert.function(callback, 'callback [function] must be provided');
 
   this._request('PATCH', uri, options, body, callback);

--- a/test/request-service-discovery.test.js
+++ b/test/request-service-discovery.test.js
@@ -90,13 +90,6 @@ describe('request-service-discovery', function () {
     done();
   });
 
-  it('calling put() with a missing body argument should throw an error', function (done) {
-    var instance = _createInstance();
-
-    (function() { instance.put('resource-name/1234', null, function(err, result) {}) }).should.throw('body [object] must be provided');
-    done();
-  });
-
   it('calling post() when the zoologist is not connected it should throw an error', function (done) {
     mockery.registerMock('./zoologist', _createDisconnectedZoologistMock());
 
@@ -119,13 +112,6 @@ describe('request-service-discovery', function () {
     var instance = _createInstance();
 
     (function() { instance.post('resource-name/1234', null, null) }).should.throw('callback [function] must be provided');
-    done();
-  });
-
-  it('calling post() with a missing body argument should throw an error', function (done) {
-    var instance = _createInstance();
-
-    (function() { instance.post('resource-name/1234', null, function(err, result) {}) }).should.throw('body [object] must be provided');
     done();
   });
 


### PR DESCRIPTION
…, Post and Put methods.  Was found to behave incorrectly if the body was of type Array, could also be an issue if String (plain text) is passed to the methods as body.